### PR TITLE
Pass maxLength to TextInput if wanted

### DIFF
--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -18,6 +18,7 @@ const viewPropTypes = ViewPropTypes || View.propTypes;
 type Props = {
   containerStyle?: viewPropTypes.style,
   maxLength?: number,
+  enforceMax: bool,
   onChangeText?: (text: string) => void,
 };
 
@@ -28,6 +29,7 @@ type State = {
 export default class Textarea extends PureComponent<Props, State> {
   static defaultProps = {
     maxLength: 0,
+    enforceMax: false,
   }
 
   constructor(props) {
@@ -60,6 +62,12 @@ export default class Textarea extends PureComponent<Props, State> {
 
   render() {
     const { containerStyle, maxLength, ...rest } = this.props;
+    
+    if(this.props.enforceMax === true)
+    {
+      rest.maxLength = maxLength;
+    }
+    
     return (
       <View style={[styles.container, containerStyle]}>
         <TextInput multiline {...rest} onChangeText={this._onChangeText} />


### PR DESCRIPTION
Passing maxLength down conditionally will allow both behaviors (type/paste then edit down vs. always enforce limit) to be implemented