### PR TITLE
added a ref to the textinput for easier focus when calling the compon…

### DIFF
--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -65,7 +65,7 @@ export default class Textarea extends PureComponent<Props, State> {
     }
     return (
       <View style={[styles.container, containerStyle]}>
-        <TextInput multiline {...rest} onChangeText={this._onChangeText} />
+        <TextInput multiline {...rest} onChangeText={this._onChangeText} ref="textarea"/>
         {this._renderCount()}
       </View>
     );


### PR DESCRIPTION
just added the ref="textarea" to the text input so focus() function can be called from anywhere the component is used as this.refs['ref-name'].refs.textarea.focus();