### PR TITLE
fix: default value counter

### DIFF
--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -33,7 +33,7 @@ export default class Textarea extends PureComponent<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      count: 0,
+      count: +(!!props.defaultValue && props.defaultValue.length),
     };
   }
 


### PR DESCRIPTION
This adds a verification for the `defaultValue` value in order to show the correct characters count in TextAreas that use this prop, otherwise even with the TextArea filled the counter displays 0